### PR TITLE
prevent explainer text from falling into the text of the previous answer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ dogs.length = 1
 (x) The array becomes just `["Fido"]`
 ( ) The array becomes just `["Odie", "Oscar"]`
 
-Refer to the following code snippet to answer the next two questions.
+?: Refer to the following code snippet to answer the next two questions.
 
 ``` javascript
 const artistsAndSongs = {


### PR DESCRIPTION
The text explaining the next two questions falls into the previous answer.

I think adding the `?:` in front of the text would fix this by making it the 6th item in the <ol>, but I didn't really have a way to test it myself because of the way the learn.co application works correct?

![screen shot 2016-07-31 at 3 41 24 pm](https://cloud.githubusercontent.com/assets/2252884/17279250/4d4da294-5735-11e6-8b8c-0ad393ba9d90.png)